### PR TITLE
Improve FEN - halfmove clock, fullmove number; optimize and fix Move creation

### DIFF
--- a/src/Extensions/StringExtensions.cs
+++ b/src/Extensions/StringExtensions.cs
@@ -1,0 +1,32 @@
+using System.Text;
+
+namespace TimHanewich.Chess.Extensions
+{
+    public static class StringExtensions
+    {
+        public static string NormalizeSpaces(this string input)
+        {
+            var output = new StringBuilder();
+            bool isSpace = false;
+
+            foreach (char c in input)
+            {
+                if (char.IsWhiteSpace(c))
+                {
+                    if (!isSpace)
+                    {
+                        output.Append(' ');
+                        isSpace = true;
+                    }
+                }
+                else
+                {
+                    output.Append(c);
+                    isSpace = false;
+                }
+            }
+
+            return output.ToString();
+        }
+    }
+}

--- a/src/Extensions/StringExtensions.cs
+++ b/src/Extensions/StringExtensions.cs
@@ -2,7 +2,7 @@ using System.Text;
 
 namespace TimHanewich.Chess.Extensions
 {
-    public static class StringExtensions
+    internal static class StringExtensions
     {
         public static string NormalizeSpaces(this string input)
         {

--- a/src/Move.cs
+++ b/src/Move.cs
@@ -369,11 +369,12 @@ namespace TimHanewich.Chess
             }
             string disecting = algebraic_notation;
 
-            //Strip out the x
+            //Strip out the x, +, #
             disecting = disecting.Replace("x", "");
+            disecting = disecting.TrimEnd('+', '#');
 
             //Get the to position
-            int? DestinationRankPosition = FindLastNumber(disecting);
+            int? DestinationRankPosition = FindIndexOfLastNumber(disecting);
             if (!DestinationRankPosition.HasValue)
             {
                 throw new InvalidOperationException("Invalid move");
@@ -448,28 +449,17 @@ namespace TimHanewich.Chess
             }));
         }
 
-        private int? FindLastNumber(string inside)
+        private int? FindIndexOfLastNumber(string input)
         {
-            int? ToReturn = null;
-            for (int t = 1; t <= 8; t++)
+            for (int i = input.Length - 1; i >= 0; i--)
             {
-                int val = inside.LastIndexOf(t.ToString());
-                if (val != -1)
+                char c = input[i];
+                if (c >= '1' && c <= '8')
                 {
-                    if (ToReturn == null)
-                    {
-                        ToReturn = val;
-                    }
-                    else
-                    {
-                        if (val > ToReturn.Value)
-                        {
-                            ToReturn = val;
-                        }
-                    }
+                    return i;
                 }
             }
-            return ToReturn;
+            return null;
         }
     
         public override string ToString()

--- a/src/PGN/PgnFile.cs
+++ b/src/PGN/PgnFile.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using TimHanewich.Chess.Extensions;
 
 namespace TimHanewich.Chess.PGN
 {
@@ -26,7 +27,8 @@ namespace TimHanewich.Chess.PGN
 
         public static PgnFile ParsePgn(string pgn)
         {
-
+            //Turn all the series of whitespaces into a single space
+            pgn = pgn.NormalizeSpaces();
             PgnFile ppl = new PgnFile();
             try
             {

--- a/src/TimHanewich.Chess.csproj
+++ b/src/TimHanewich.Chess.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Authors>Tim Hanewich</Authors>
-    <Version>0.5.0</Version>
+    <Version>0.7.0</Version>
     <Description>Various resources for parsing PGN, evaluating positions, parsing and printing FEN, and more.</Description>
     <PackageIcon>pawn.png</PackageIcon>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/test/MoveTest.cs
+++ b/test/MoveTest.cs
@@ -5,23 +5,23 @@ using Xunit;
 namespace test
 {
     public class MoveTest
-    {
-        private const string InitialPosition = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-        
+    {        
         [Fact]
         public void CreateMove()
         {
-            var board = new BoardPosition(InitialPosition);
+            var board = BoardPosition.NewGame();
             var move = new Move("e4", board);
             Assert.Equal(Position.E2, move.FromPosition);
             Assert.Equal(Position.E4, move.ToPosition);
         }
 
-        [Fact]
-        public void ExecuteGame()
+        [Theory]
+        [InlineData("game1.pgn", "1r5r/5Qk1/1p2b1p1/pPp1P1q1/P2p4/3P2P1/1P4B1/4RRK1 b - - 0 30")]
+        [InlineData("game2.pgn", "8/8/4R1p1/2k3p1/1p4P1/1P1b1P2/3K1n2/8 b - - 2 43")]
+        public void ExecuteGame(string gameFile, string expectedFen)
         {
-            var board = new BoardPosition(InitialPosition);
-            string content = System.IO.File.ReadAllText("../../../game1.pgn");
+            var board = BoardPosition.NewGame();
+            string content = System.IO.File.ReadAllText($"../../../{gameFile}");
             PgnFile pgn = PgnFile.ParsePgn(content);
 
             foreach (var moveString in pgn.Moves)
@@ -30,7 +30,7 @@ namespace test
                 board.ExecuteMove(move);
             }
 
-            Assert.Equal("1r5r/5Qk1/1p2b1p1/pPp1P1q1/P2p4/3P2P1/1P4B1/4RRK1 b - -", board.ToFEN());
+            Assert.Equal(expectedFen, board.ToFEN());
         }
     }
 }

--- a/test/game2.pgn
+++ b/test/game2.pgn
@@ -1,0 +1,16 @@
+[Event "F/S Return Match"]
+[Site "Belgrade, Serbia JUG"]
+[Date "1992.11.04"]
+[Round "29"]
+[White "Fischer, Robert J."]
+[Black "Spassky, Boris V."]
+[Result "1/2-1/2"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 {This opening is called the Ruy Lopez.}
+4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Nb8 10. d4 Nbd7
+11. c4 c6 12. cxb5 axb5 13. Nc3 Bb7 14. Bg5 b4 15. Nb1 h6 16. Bh4 c5 17. dxe5
+Nxe4 18. Bxe7 Qxe7 19. exd6 Qf6 20. Nbd2 Nxd6 21. Nc4 Nxc4 22. Bxc4 Nb6
+23. Ne5 Rae8 24. Bxf7+ Rxf7 25. Nxf7 Rxe1+ 26. Qxe1 Kxf7 27. Qe3 Qg5 28. Qxg5
+hxg5 29. b3 Ke6 30. a3 Kd6 31. axb4 cxb4 32. Ra5 Nd5 33. f3 Bc8 34. Kf2 Bf5
+35. Ra7 g6 36. Ra6+ Kc5 37. Ke1 Nf4 38. g3 Nxh3 39. Kd2 Kb5 40. Rd6 Kc5 41. Ra6
+Nf2 42. g4 Bd3 43. Re6 1/2-1/2


### PR DESCRIPTION
Improve FEN - add halfmove clock and fullmove number according to https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation
Fix move creation when check.
Optimize some methods.
Fix problem of multiple whitespaces in PGN.